### PR TITLE
🐛 Handle corner case in pi0 estimation

### DIFF
--- a/crema/qvalues.py
+++ b/crema/qvalues.py
@@ -194,7 +194,13 @@ def mixmax(target_scores, decoy_scores, combined_score, combined_score_target):
     pval_list = np.array(pval_list) / n_decoys
 
     # calculate pi0
-    pi0 = estimate_pi0(pval_list)
+    if len(pval_list) > 0:
+        pi0 = estimate_pi0(pval_list)
+    else:
+        # Corner case: if pval_list is empty there are no targets.
+        # In this case pi0 is undefined, but we set it to 1.0, as all
+        # provided targets are incorrect, and we avoid zeroes.
+        pi0 = 1.0
 
     if pi0 == 1.0:
         # All targets are assumed to be incorrect! Algorithm 1, line 5-6

--- a/tests/unit_tests/test_qvalues.py
+++ b/tests/unit_tests/test_qvalues.py
@@ -208,3 +208,18 @@ def test_mixmax_nonsingular(mixmax_scores):
         pi0, qvals = do_mixmax(scores, target.astype(dtype), desc=False)
         assert pi0 != 1.0
         assert any(q != 1.0 for q in qvals)
+
+
+def test_mixmax_empty():
+    """Test that q-values can be computed for pi0 != 1.0"""
+    scores, target = np.array([], dtype=float), np.array([], dtype=float)
+
+    dtypes = [np.float64, np.uint8, np.int8, np.float32]
+    for dtype in dtypes:
+        pi0, qvals = do_mixmax(scores.astype(dtype), target, desc=False)
+        assert pi0 != 1.0
+        assert any(q != 1.0 for q in qvals)
+
+        pi0, qvals = do_mixmax(scores, target.astype(dtype), desc=False)
+        assert pi0 != 1.0
+        assert any(q != 1.0 for q in qvals)

--- a/tests/unit_tests/test_qvalues.py
+++ b/tests/unit_tests/test_qvalues.py
@@ -217,9 +217,9 @@ def test_mixmax_empty():
     dtypes = [np.float64, np.uint8, np.int8, np.float32]
     for dtype in dtypes:
         pi0, qvals = do_mixmax(scores.astype(dtype), target, desc=False)
-        assert pi0 != 1.0
-        assert any(q != 1.0 for q in qvals)
+        assert pi0 == 1.0
+        assert all(q == 1.0 for q in qvals)
 
         pi0, qvals = do_mixmax(scores, target.astype(dtype), desc=False)
-        assert pi0 != 1.0
-        assert any(q != 1.0 for q in qvals)
+        assert pi0 == 1.0
+        assert all(q == 1.0 for q in qvals)


### PR DESCRIPTION
When passing an empty list of _p_-values to `estimate_pi0`, `njit` raises a `ZeroDivisionError` (without stack trace), crashing the process. To handle this case gracefully we can instead estimate `pi0 = 1.0`.